### PR TITLE
Add Supabase-based messaging

### DIFF
--- a/MotivezApp/README.md
+++ b/MotivezApp/README.md
@@ -35,6 +35,26 @@ npm run reset-project
 
 This command will move the starter code to the **app-example** directory and create a blank **app** directory where you can start developing.
 
+## Supabase Messaging Setup
+
+1. Create a project at [Supabase](https://supabase.com/) and note the project URL and anon key.
+2. Create two tables in your Supabase database:
+   - **chats**: `id` UUID primary key, `user_id` text, `name` text, `avatar_url` text, `last_message` text, `updated_at` timestamp, `unread` integer.
+   - **messages**: `id` UUID primary key, `chat_id` UUID reference to `chats.id`, `sender_id` text, `content` text, `created_at` timestamp default `now()`, `reaction` text.
+3. Add your credentials to a `.env` file in this directory:
+
+```bash
+EXPO_PUBLIC_SUPABASE_URL=<your-supabase-url>
+EXPO_PUBLIC_SUPABASE_ANON_KEY=<your-anon-key>
+```
+
+4. Install dependencies and run the project:
+
+```bash
+npm install
+npx expo start
+```
+
 ## Learn more
 
 To learn more about developing your project with Expo, look at the following resources:

--- a/MotivezApp/app.config.js
+++ b/MotivezApp/app.config.js
@@ -47,7 +47,9 @@ export default {
       typedRoutes: true
     },
     extra: {
-      googleMapsApiKey: process.env.GOOGLE_MAPS_API_KEY
+      googleMapsApiKey: process.env.GOOGLE_MAPS_API_KEY,
+      supabaseUrl: process.env.EXPO_PUBLIC_SUPABASE_URL,
+      supabaseAnonKey: process.env.EXPO_PUBLIC_SUPABASE_ANON_KEY
     }
   }
 };

--- a/MotivezApp/app/lib/supabase.ts
+++ b/MotivezApp/app/lib/supabase.ts
@@ -1,0 +1,7 @@
+import { createClient } from '@supabase/supabase-js';
+import 'react-native-url-polyfill/auto';
+
+const supabaseUrl = process.env.EXPO_PUBLIC_SUPABASE_URL || '';
+const supabaseAnonKey = process.env.EXPO_PUBLIC_SUPABASE_ANON_KEY || '';
+
+export const supabase = createClient(supabaseUrl, supabaseAnonKey);

--- a/MotivezApp/app/menu/messages/[chatId].tsx
+++ b/MotivezApp/app/menu/messages/[chatId].tsx
@@ -1,0 +1,142 @@
+import React, { useEffect, useState } from 'react';
+import { View, Text, StyleSheet, TextInput, TouchableOpacity, FlatList, GestureResponderEvent } from 'react-native';
+import { Stack, useLocalSearchParams } from 'expo-router';
+import { Ionicons } from '@expo/vector-icons';
+import dayjs from 'dayjs';
+import { supabase } from '../../lib/supabase';
+
+interface Message {
+  id: string;
+  chat_id: string;
+  sender_id: string;
+  content: string;
+  created_at: string;
+  reaction?: string | null;
+}
+
+const CURRENT_USER_ID = 'demo-user'; // replace with your auth user id
+
+export default function ChatDetail() {
+  const { chatId } = useLocalSearchParams<{ chatId: string }>();
+  const [messages, setMessages] = useState<Message[]>([]);
+  const [input, setInput] = useState('');
+
+  useEffect(() => {
+    fetchMessages();
+    const channel = supabase
+      .channel('messages')
+      .on(
+        'postgres_changes',
+        { event: 'INSERT', schema: 'public', table: 'messages', filter: `chat_id=eq.${chatId}` },
+        payload => {
+          setMessages(prev => [...prev, payload.new as Message]);
+        }
+      )
+      .subscribe();
+    return () => {
+      supabase.removeChannel(channel);
+    };
+  }, [chatId]);
+
+  async function fetchMessages() {
+    const { data } = await supabase
+      .from('messages')
+      .select('*')
+      .eq('chat_id', chatId as string)
+      .order('created_at', { ascending: true });
+    if (data) setMessages(data as Message[]);
+  }
+
+  async function sendMessage() {
+    if (!input.trim()) return;
+    await supabase.from('messages').insert({
+      chat_id: chatId,
+      sender_id: CURRENT_USER_ID,
+      content: input.trim(),
+    });
+    setInput('');
+  }
+
+  async function addReaction(messageId: string, reaction: string) {
+    await supabase
+      .from('messages')
+      .update({ reaction })
+      .eq('id', messageId);
+  }
+
+  const handleLongPress = (id: string) => (e: GestureResponderEvent) => {
+    addReaction(id, '❤️');
+  };
+
+  const renderItem = ({ item }: { item: Message }) => (
+    <TouchableOpacity
+      onLongPress={handleLongPress(item.id)}
+      style={[styles.message, item.sender_id === CURRENT_USER_ID ? styles.me : styles.them]}
+    >
+      <Text style={styles.text}>{item.content}</Text>
+      <View style={styles.metaRow}>
+        {item.reaction && <Text style={styles.reaction}>{item.reaction}</Text>}
+        <Text style={styles.time}>{dayjs(item.created_at).format('HH:mm')}</Text>
+      </View>
+    </TouchableOpacity>
+  );
+
+  return (
+    <>
+      <Stack.Screen options={{ title: 'Chat' }} />
+      <View style={styles.container}>
+        <FlatList
+          data={messages}
+          keyExtractor={(item) => item.id}
+          renderItem={renderItem}
+          contentContainerStyle={styles.list}
+        />
+        <View style={styles.inputRow}>
+          <TextInput
+            style={styles.input}
+            value={input}
+            onChangeText={setInput}
+            placeholder="Message"
+          />
+          <TouchableOpacity onPress={sendMessage} style={styles.sendButton}>
+            <Ionicons name="send" size={24} color="#007AFF" />
+          </TouchableOpacity>
+        </View>
+      </View>
+    </>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, backgroundColor: '#ffffff' },
+  list: { padding: 12 },
+  message: {
+    marginBottom: 12,
+    padding: 10,
+    borderRadius: 8,
+    maxWidth: '80%',
+  },
+  me: { alignSelf: 'flex-end', backgroundColor: '#DCF8C6' },
+  them: { alignSelf: 'flex-start', backgroundColor: '#f2f2f2' },
+  text: { fontSize: 16 },
+  metaRow: { flexDirection: 'row', justifyContent: 'flex-end', marginTop: 4 },
+  time: { fontSize: 12, color: '#999', marginLeft: 6 },
+  reaction: { fontSize: 14 },
+  inputRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    padding: 8,
+    borderTopWidth: 1,
+    borderColor: '#eee',
+  },
+  input: {
+    flex: 1,
+    borderWidth: 1,
+    borderColor: '#ccc',
+    borderRadius: 20,
+    paddingHorizontal: 12,
+    paddingVertical: 8,
+    marginRight: 8,
+  },
+  sendButton: { padding: 4 },
+});

--- a/MotivezApp/package.json
+++ b/MotivezApp/package.json
@@ -55,7 +55,9 @@
     "react-native-shared-element": "^0.8.9",
     "react-native-web": "^0.20.0",
     "react-native-webview": "13.13.5",
-    "react-navigation-shared-element": "^3.1.3"
+    "react-navigation-shared-element": "^3.1.3",
+    "@supabase/supabase-js": "^2.43.1",
+    "react-native-url-polyfill": "^1.3.0"
   },
   "devDependencies": {
     "@babel/core": "^7.25.2",

--- a/README.md
+++ b/README.md
@@ -39,6 +39,25 @@ Many people struggle with **finding something to do** when they're bored. Motive
 - **APIs Used:** Google Maps API, OpenWeather API (optional for weather-based recommendations)
 - **Authentication:** Firebase Auth (for user login, business owner login, & friend invites)
 
+### Messaging with Supabase
+The new messaging feature stores chats and messages using [Supabase](https://supabase.com/).
+Add your Supabase credentials to a `.env` file in `MotivezApp/`:
+
+```bash
+EXPO_PUBLIC_SUPABASE_URL=<your-supabase-url>
+EXPO_PUBLIC_SUPABASE_ANON_KEY=<your-anon-key>
+```
+
+After setting the keys, install dependencies and run the app:
+
+```bash
+cd MotivezApp
+npm install
+npx expo start
+```
+
+See `MotivezApp/README.md` for a detailed setup.
+
 ---
 
 ## **🚀 Future Plans**


### PR DESCRIPTION
## Summary
- add Supabase client and messaging views
- show chat list using Supabase data
- implement chat detail screen with realtime updates and emoji reaction
- document Supabase setup in both READMEs

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ce01ba120832487e725e3a2533500