### PR TITLE
Add web fallback for react-native-maps usage

### DIFF
--- a/MotivezApp/app/maps/_index.tsx
+++ b/MotivezApp/app/maps/_index.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from "react";
 import { View, StyleSheet, ActivityIndicator, Text, TouchableOpacity, TextInput, Dimensions } from "react-native";
-import MapView, { Marker, PROVIDER_GOOGLE } from "react-native-maps";
+import MapView, { Marker, PROVIDER_GOOGLE } from "../../components/CustomMapView";
 import * as Location from "expo-location";
 import { Stack, useRouter } from "expo-router";
 import { Ionicons } from "@expo/vector-icons";

--- a/MotivezApp/app/motive-detail.tsx
+++ b/MotivezApp/app/motive-detail.tsx
@@ -4,7 +4,7 @@ import { useLocalSearchParams, useRouter } from 'expo-router';
 import { SharedElement } from 'react-navigation-shared-element';
 import { LinearGradient } from 'expo-linear-gradient';
 import { Ionicons } from '@expo/vector-icons';
-import MapView, { Marker } from 'react-native-maps';
+import MapView, { Marker } from '../components/CustomMapView';
 import { SafeAreaView } from 'react-native-safe-area-context';
 
 const { width, height } = Dimensions.get('window');

--- a/MotivezApp/components/CustomMapView.tsx
+++ b/MotivezApp/components/CustomMapView.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import { Platform, View, Text, StyleSheet } from 'react-native';
+import MapView, { Marker, PROVIDER_GOOGLE, MapViewProps } from 'react-native-maps';
+
+const Placeholder = ({ style }: { style?: MapViewProps['style'] }) => (
+  <View style={[styles.placeholder, style]}>
+    <Text>Map not available on web</Text>
+  </View>
+);
+
+const CustomMapView: React.FC<MapViewProps> = (props) => {
+  if (Platform.OS === 'web') {
+    return <Placeholder style={props.style} />;
+  }
+  return <MapView {...props} />;
+};
+
+const styles = StyleSheet.create({
+  placeholder: {
+    backgroundColor: '#eee',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+});
+
+export { Marker, PROVIDER_GOOGLE };
+export default CustomMapView;

--- a/MotivezApp/components/DeckSwiper.tsx
+++ b/MotivezApp/components/DeckSwiper.tsx
@@ -3,7 +3,7 @@ import React, { useState, useRef } from 'react';
 import { View, Text, StyleSheet, Dimensions, TouchableOpacity, Image, Modal, ScrollView } from 'react-native';
 import Swiper from 'react-native-deck-swiper';
 import { Feather, MaterialIcons } from '@expo/vector-icons';
-import MapView, { Marker, PROVIDER_GOOGLE } from 'react-native-maps';
+import MapView, { Marker, PROVIDER_GOOGLE } from './CustomMapView';
 
 const { width, height } = Dimensions.get('window');
 


### PR DESCRIPTION
## Summary
- add `CustomMapView` component that shows a placeholder on web
- update all map imports to use the new component

## Testing
- `npm run lint` *(fails: `expo` not found)*
- `npm test` *(fails: `jest` not found)*
- `npx tsc -p tsconfig.json --noEmit` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_684cec1da84c8324b18886363ab6ffc9