### PR TITLE
Fix time formatting without dayjs

### DIFF
--- a/MotivezApp/app/lib/formatTime.ts
+++ b/MotivezApp/app/lib/formatTime.ts
@@ -1,0 +1,6 @@
+export function formatTime(dateString: string): string {
+  const date = new Date(dateString);
+  const hours = date.getHours().toString().padStart(2, '0');
+  const minutes = date.getMinutes().toString().padStart(2, '0');
+  return `${hours}:${minutes}`;
+}

--- a/MotivezApp/app/menu/messages.tsx
+++ b/MotivezApp/app/menu/messages.tsx
@@ -11,7 +11,7 @@ import {
 import { useRouter, Stack } from 'expo-router';
 import { Ionicons } from '@expo/vector-icons';
 import { SafeAreaView } from 'react-native-safe-area-context';
-import dayjs from 'dayjs';
+import { formatTime } from '../lib/formatTime';
 import { supabase } from '../lib/supabase';
 
 interface Chat {
@@ -53,7 +53,7 @@ export default function MessagesScreen() {
       <View style={styles.chatInfo}>
         <View style={styles.chatTitleRow}>
           <Text style={styles.chatName}>{item.name}</Text>
-          <Text style={styles.chatTime}>{dayjs(item.updated_at).format('HH:mm')}</Text>
+          <Text style={styles.chatTime}>{formatTime(item.updated_at)}</Text>
         </View>
         <Text style={styles.lastMessage} numberOfLines={1}>
           {item.last_message}

--- a/MotivezApp/app/menu/messages/[chatId].tsx
+++ b/MotivezApp/app/menu/messages/[chatId].tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from 'react';
 import { View, Text, StyleSheet, TextInput, TouchableOpacity, FlatList, GestureResponderEvent } from 'react-native';
 import { Stack, useLocalSearchParams } from 'expo-router';
 import { Ionicons } from '@expo/vector-icons';
-import dayjs from 'dayjs';
+import { formatTime } from '../../lib/formatTime';
 import { supabase } from '../../lib/supabase';
 
 interface Message {
@@ -76,7 +76,7 @@ export default function ChatDetail() {
       <Text style={styles.text}>{item.content}</Text>
       <View style={styles.metaRow}>
         {item.reaction && <Text style={styles.reaction}>{item.reaction}</Text>}
-        <Text style={styles.time}>{dayjs(item.created_at).format('HH:mm')}</Text>
+        <Text style={styles.time}>{formatTime(item.created_at)}</Text>
       </View>
     </TouchableOpacity>
   );


### PR DESCRIPTION
## Summary
- replace `dayjs` usage with local `formatTime` helper
- add simple time formatting util

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_684cf30a290883248ed09130648aca6d