### PR TITLE
Improve menu UI with shared color theme

### DIFF
--- a/MotivezApp/app/menu/about.tsx
+++ b/MotivezApp/app/menu/about.tsx
@@ -3,6 +3,7 @@ import { View, Text, StyleSheet, TouchableOpacity, Linking, ScrollView } from 'r
 import { useRouter, Stack } from 'expo-router';
 import { Ionicons } from '@expo/vector-icons';
 import { SafeAreaView } from 'react-native-safe-area-context';
+import { colors } from '../../constants/Colors';
 
 export default function About() {
   const router = useRouter();
@@ -14,7 +15,7 @@ export default function About() {
         {/* Top Bar with Back Button */}
         <View style={styles.topBar}>
           <TouchableOpacity onPress={() => router.back()} style={styles.backButton}>
-            <Ionicons name="arrow-back" size={28} color="#333" />
+            <Ionicons name="arrow-back" size={28} color={colors.text} />
           </TouchableOpacity>
           <Text style={styles.topTitle}>About Motivez</Text>
         </View>
@@ -120,7 +121,7 @@ export default function About() {
 const styles = StyleSheet.create({
   safeArea: {
     flex: 1,
-    backgroundColor: "#f4f6f8",
+    backgroundColor: colors.background,
   },
   topBar: {
     flexDirection: "row",
@@ -128,9 +129,9 @@ const styles = StyleSheet.create({
     paddingHorizontal: 16,
     paddingTop: 50,
     paddingBottom: 10,
-    backgroundColor: "#ffffff",
+    backgroundColor: colors.surface,
     borderBottomWidth: 1,
-    borderBottomColor: "#dddddd",
+    borderBottomColor: colors.border,
   },
   backButton: {
     padding: 4,
@@ -139,7 +140,7 @@ const styles = StyleSheet.create({
     flex: 1,
     fontSize: 20,
     fontWeight: "600",
-    color: "#333333",
+    color: colors.text,
     textAlign: "center",
     marginRight: 32, // to offset back arrow width
   },
@@ -155,12 +156,12 @@ const styles = StyleSheet.create({
   appName: {
     fontSize: 32,
     fontWeight: "bold",
-    color: "#007AFF",
+    color: colors.primary,
     marginTop: 8,
   },
   tagline: {
     fontSize: 16,
-    color: "#666666",
+    color: colors.textSecondary,
     marginTop: 4,
   },
   section: {
@@ -169,12 +170,12 @@ const styles = StyleSheet.create({
   sectionTitle: {
     fontSize: 20,
     fontWeight: "600",
-    color: "#333333",
+    color: colors.text,
     marginBottom: 8,
   },
   sectionText: {
     fontSize: 16,
-    color: "#555555",
+    color: colors.textSecondary,
     lineHeight: 22,
   },
   bulletItem: {
@@ -185,12 +186,12 @@ const styles = StyleSheet.create({
   bulletText: {
     flex: 1,
     fontSize: 16,
-    color: "#555555",
+    color: colors.textSecondary,
     marginLeft: 8,
     lineHeight: 22,
   },
   linkText: {
-    color: "#007AFF",
+    color: colors.primary,
     textDecorationLine: "underline",
   },
   footerSection: {
@@ -199,14 +200,14 @@ const styles = StyleSheet.create({
   },
   footerText: {
     fontSize: 14,
-    color: "#888888",
+    color: colors.textSecondary,
     marginVertical: 2,
   },
   container: {
     flex: 1,
     justifyContent: "center",
     alignItems: "center",
-    backgroundColor: "#f4f6f8",
+    backgroundColor: colors.background,
   },
   text: {
     fontSize: 24,

--- a/MotivezApp/app/menu/calendar.tsx
+++ b/MotivezApp/app/menu/calendar.tsx
@@ -11,6 +11,7 @@ import {
 import { useRouter, Stack } from 'expo-router';
 import { Ionicons } from '@expo/vector-icons';
 import { SafeAreaView } from 'react-native-safe-area-context';
+import { colors } from '../../constants/Colors';
 import { Calendar } from 'react-native-calendars';
 
 // Dummy motives/events by date
@@ -47,7 +48,7 @@ export default function CalendarScreen() {
         {/* Top Bar */}
         <View style={styles.topBar}>
           <TouchableOpacity onPress={() => router.back()} style={styles.backButton}>
-            <Ionicons name="arrow-back" size={28} color="#333" />
+            <Ionicons name="arrow-back" size={28} color={colors.text} />
           </TouchableOpacity>
           <Text style={styles.topTitle}>Calendar</Text>
           <View style={{ width: 32 }} /> {/* Spacer */}
@@ -58,7 +59,7 @@ export default function CalendarScreen() {
           markedDates={markedDates}
           onDayPress={day => setSelected(day.dateString)}
           theme={{
-            backgroundColor: '#f4f6f8',
+            backgroundColor: colors.background,
             calendarBackground: '#fff',
             textSectionTitleColor: '#222',
             selectedDayBackgroundColor: '#e91e63',
@@ -88,7 +89,7 @@ export default function CalendarScreen() {
             keyExtractor={item => item.id}
             renderItem={({ item }) => (
               <View style={styles.motiveItem}>
-                <Ionicons name="calendar-outline" size={22} color="#007AFF" style={{ marginRight: 10 }} />
+                <Ionicons name="calendar-outline" size={22} color={colors.primary} style={{ marginRight: 10 }} />
                 <Text style={styles.motiveTitle}>{item.title}</Text>
                 <Text style={styles.motiveTime}>@ {item.time}</Text>
               </View>
@@ -106,7 +107,7 @@ export default function CalendarScreen() {
 const styles = StyleSheet.create({
   safeArea: {
     flex: 1,
-    backgroundColor: '#f4f6f8',
+    backgroundColor: colors.background,
   },
   topBar: {
     flexDirection: 'row',
@@ -114,9 +115,9 @@ const styles = StyleSheet.create({
     paddingHorizontal: 16,
     paddingTop: 20,
     paddingBottom: 10,
-    backgroundColor: '#ffffff',
+    backgroundColor: colors.surface,
     borderBottomWidth: 1,
-    borderBottomColor: '#dddddd',
+    borderBottomColor: colors.border,
   },
   backButton: {
     width: 32,
@@ -126,7 +127,7 @@ const styles = StyleSheet.create({
     flex: 1,
     fontSize: 20,
     fontWeight: '600',
-    color: '#333333',
+    color: colors.text,
     textAlign: 'center',
   },
   calendar: {
@@ -145,7 +146,7 @@ const styles = StyleSheet.create({
   subheading: {
     fontSize: 16,
     fontWeight: '700',
-    color: '#007AFF',
+    color: colors.primary,
     marginBottom: 10,
     marginLeft: 4,
   },

--- a/MotivezApp/app/menu/categories.tsx
+++ b/MotivezApp/app/menu/categories.tsx
@@ -10,6 +10,7 @@ import {
 import { useRouter, Stack } from 'expo-router';
 import { Ionicons } from '@expo/vector-icons';
 import { SafeAreaView } from 'react-native-safe-area-context';
+import { colors } from '../../constants/Colors';
 
 const categories = [
   { id: 'fun', label: '🎉 Fun' },
@@ -36,7 +37,7 @@ export default function CategoriesScreen() {
         {/* Top Bar */}
         <View style={styles.topBar}>
           <TouchableOpacity onPress={() => router.back()} style={styles.backButton}>
-            <Ionicons name="arrow-back" size={28} color="#333" />
+            <Ionicons name="arrow-back" size={28} color={colors.text} />
           </TouchableOpacity>
           <Text style={styles.topTitle}>Categories</Text>
           <View style={{ width: 32 }} /> {/* placeholder to center title */}
@@ -115,7 +116,7 @@ export default function CategoriesScreen() {
 const styles = StyleSheet.create({
   safeArea: {
     flex: 1,
-    backgroundColor: '#f4f6f8',
+    backgroundColor: colors.background,
   },
   topBar: {
     flexDirection: 'row',
@@ -123,9 +124,9 @@ const styles = StyleSheet.create({
     paddingHorizontal: 16,
     paddingTop: 20,
     paddingBottom: 10,
-    backgroundColor: '#ffffff',
+    backgroundColor: colors.surface,
     borderBottomWidth: 1,
-    borderBottomColor: '#dddddd',
+    borderBottomColor: colors.border,
   },
   backButton: {
     width: 32,
@@ -135,25 +136,25 @@ const styles = StyleSheet.create({
     flex: 1,
     fontSize: 20,
     fontWeight: '600',
-    color: '#333333',
+    color: colors.text,
     textAlign: 'center',
   },
   container: {
     paddingHorizontal: 16,
     paddingTop: 24,
     paddingBottom: 40,
-    backgroundColor: '#f4f6f8',
+    backgroundColor: colors.background,
     minHeight: '100%',
   },
   heading: {
     fontSize: 24,
     fontWeight: '700',
-    color: '#333',
+    color: colors.text,
     marginBottom: 8,
   },
   subtext: {
     fontSize: 16,
-    color: '#555',
+    color: colors.textSecondary,
     marginBottom: 20,
     lineHeight: 22,
   },
@@ -164,7 +165,7 @@ const styles = StyleSheet.create({
     paddingVertical: 8,
     paddingHorizontal: 16,
     borderRadius: 20,
-    backgroundColor: '#ffffff',
+    backgroundColor: colors.surface,
     marginRight: 12,
     borderWidth: 1,
     borderColor: '#cccccc',
@@ -175,7 +176,7 @@ const styles = StyleSheet.create({
   },
   chipText: {
     fontSize: 16,
-    color: '#333333',
+    color: colors.text,
   },
   chipTextSelected: {
     color: '#ffffff',
@@ -184,7 +185,7 @@ const styles = StyleSheet.create({
   selectedSection: {
     marginTop: 24,
     padding: 16,
-    backgroundColor: '#ffffff',
+    backgroundColor: colors.surface,
     borderRadius: 10,
     shadowColor: '#000',
     shadowOpacity: 0.05,
@@ -194,12 +195,12 @@ const styles = StyleSheet.create({
   },
   selectedText: {
     fontSize: 16,
-    color: '#333',
+    color: colors.text,
     marginBottom: 8,
   },
   selectedCategoryLabel: {
     fontWeight: '700',
-    color: '#007AFF',
+    color: colors.primary,
   },
   placeholderContent: {
     fontSize: 14,

--- a/MotivezApp/app/menu/explore.tsx
+++ b/MotivezApp/app/menu/explore.tsx
@@ -12,6 +12,7 @@ import {
 import { useRouter, Stack } from 'expo-router';
 import { Ionicons } from '@expo/vector-icons';
 import { SafeAreaView } from 'react-native-safe-area-context';
+import { colors } from '../../constants/Colors';
 
 // Dummy data for trending/public motives
 const dummyTrending = [
@@ -97,7 +98,7 @@ export default function Explore() {
         {/* Top Bar with Back Button and Title */}
         <View style={styles.topBar}>
           <TouchableOpacity onPress={() => router.back()} style={styles.backButton}>
-            <Ionicons name="arrow-back" size={28} color="#333" />
+            <Ionicons name="arrow-back" size={28} color={colors.text} />
           </TouchableOpacity>
           <Text style={styles.topTitle}>Explore & Trending</Text>
           <View style={{ width: 32 }} /> {/* spacer to center title */}
@@ -106,7 +107,7 @@ export default function Explore() {
         {/* Content */}
         {loading ? (
           <View style={styles.loaderContainer}>
-            <ActivityIndicator size="large" color="#007AFF" />
+            <ActivityIndicator size="large" color={colors.primary} />
             <Text style={styles.loadingText}>Loading Trending Motives...</Text>
           </View>
         ) : (
@@ -126,7 +127,7 @@ export default function Explore() {
 const styles = StyleSheet.create({
   safeArea: {
     flex: 1,
-    backgroundColor: '#f4f6f8',
+    backgroundColor: colors.background,
   },
   topBar: {
     flexDirection: 'row',
@@ -134,9 +135,9 @@ const styles = StyleSheet.create({
     paddingHorizontal: 16,
     paddingTop: 20,
     paddingBottom: 10,
-    backgroundColor: '#ffffff',
+    backgroundColor: colors.surface,
     borderBottomWidth: 1,
-    borderBottomColor: '#dddddd',
+    borderBottomColor: colors.border,
   },
   backButton: {
     width: 32,
@@ -146,7 +147,7 @@ const styles = StyleSheet.create({
     flex: 1,
     fontSize: 20,
     fontWeight: '600',
-    color: '#333333',
+    color: colors.text,
     textAlign: 'center',
   },
   loaderContainer: {
@@ -157,7 +158,7 @@ const styles = StyleSheet.create({
   loadingText: {
     marginTop: 12,
     fontSize: 16,
-    color: '#555555',
+    color: colors.textSecondary,
   },
   listContent: {
     paddingHorizontal: 16,
@@ -165,7 +166,7 @@ const styles = StyleSheet.create({
     paddingBottom: 40,
   },
   cardContainer: {
-    backgroundColor: '#ffffff',
+    backgroundColor: colors.surface,
     borderRadius: 12,
     marginBottom: 16,
     shadowColor: '#000',
@@ -186,7 +187,7 @@ const styles = StyleSheet.create({
   cardTitle: {
     fontSize: 18,
     fontWeight: '600',
-    color: '#333333',
+    color: colors.text,
     marginBottom: 6,
   },
   cardFooter: {
@@ -196,7 +197,7 @@ const styles = StyleSheet.create({
   },
   cardUser: {
     fontSize: 14,
-    color: '#777777',
+    color: colors.textSecondary,
   },
   likesRow: {
     flexDirection: 'row',
@@ -204,14 +205,14 @@ const styles = StyleSheet.create({
   },
   likesText: {
     fontSize: 14,
-    color: '#777777',
+    color: colors.textSecondary,
     marginLeft: 4,
   },
   container: {
     flex: 1,
     justifyContent: 'center',
     alignItems: 'center',
-    backgroundColor: '#f4f6f8',
+    backgroundColor: colors.background,
   },
   text: {
     fontSize: 24,

--- a/MotivezApp/app/menu/friends.tsx
+++ b/MotivezApp/app/menu/friends.tsx
@@ -12,6 +12,7 @@ import {
 import { useRouter, Stack } from 'expo-router';
 import { Ionicons } from '@expo/vector-icons';
 import { SafeAreaView } from 'react-native-safe-area-context';
+import { colors } from '../../constants/Colors';
 
 const SCREEN_WIDTH = Dimensions.get('window').width;
 
@@ -95,7 +96,7 @@ export default function FriendsScreen() {
         {/* Top Bar */}
         <View style={styles.topBar}>
           <TouchableOpacity onPress={() => router.back()} style={styles.backButton}>
-            <Ionicons name="arrow-back" size={28} color="#333" />
+            <Ionicons name="arrow-back" size={28} color={colors.text} />
           </TouchableOpacity>
           <Text style={styles.topTitle}>Friends</Text>
           <View style={{ width: 32 }} /> {/* Spacer to center title */}
@@ -103,7 +104,7 @@ export default function FriendsScreen() {
 
         {loading ? (
           <View style={styles.loaderContainer}>
-            <ActivityIndicator size="large" color="#007AFF" />
+            <ActivityIndicator size="large" color={colors.primary} />
             <Text style={styles.loadingText}>Loading Friends...</Text>
           </View>
         ) : (
@@ -123,7 +124,7 @@ export default function FriendsScreen() {
 const styles = StyleSheet.create({
   safeArea: {
     flex: 1,
-    backgroundColor: '#f4f6f8',
+    backgroundColor: colors.background,
   },
   topBar: {
     flexDirection: 'row',
@@ -131,9 +132,9 @@ const styles = StyleSheet.create({
     paddingHorizontal: 16,
     paddingTop: 20,
     paddingBottom: 10,
-    backgroundColor: '#ffffff',
+    backgroundColor: colors.surface,
     borderBottomWidth: 1,
-    borderBottomColor: '#dddddd',
+    borderBottomColor: colors.border,
   },
   backButton: {
     width: 32,
@@ -143,7 +144,7 @@ const styles = StyleSheet.create({
     flex: 1,
     fontSize: 20,
     fontWeight: '600',
-    color: '#333333',
+    color: colors.text,
     textAlign: 'center',
   },
   loaderContainer: {
@@ -154,7 +155,7 @@ const styles = StyleSheet.create({
   loadingText: {
     marginTop: 12,
     fontSize: 16,
-    color: '#555555',
+    color: colors.textSecondary,
   },
   listContent: {
     paddingHorizontal: 16,
@@ -164,7 +165,7 @@ const styles = StyleSheet.create({
   friendCard: {
     flexDirection: 'row',
     alignItems: 'center',
-    backgroundColor: '#ffffff',
+    backgroundColor: colors.surface,
     borderRadius: 10,
     marginBottom: 12,
     padding: 12,
@@ -186,11 +187,11 @@ const styles = StyleSheet.create({
   friendName: {
     fontSize: 16,
     fontWeight: '600',
-    color: '#333333',
+    color: colors.text,
   },
   friendStatus: {
     fontSize: 14,
-    color: '#777777',
+    color: colors.textSecondary,
     marginTop: 4,
   },
   chatButton: {

--- a/MotivezApp/app/menu/help.tsx
+++ b/MotivezApp/app/menu/help.tsx
@@ -3,6 +3,7 @@ import { View, Text, StyleSheet, TouchableOpacity, ScrollView, Linking } from 'r
 import { useRouter, Stack } from 'expo-router';
 import { Ionicons } from '@expo/vector-icons';
 import { SafeAreaView } from 'react-native-safe-area-context';
+import { colors } from '../../constants/Colors';
 
 export default function Help() {
   const router = useRouter();
@@ -14,10 +15,10 @@ export default function Help() {
   return (
     <>
       <Stack.Screen options={{ headerShown: false }} />
-      <SafeAreaView style={{ flex: 1, backgroundColor: '#f4f6f8' }}>
+      <SafeAreaView style={{ flex: 1, backgroundColor: colors.background }}>
         <View style={styles.topBar}>
           <TouchableOpacity onPress={() => router.back()} style={styles.backButton}>
-            <Ionicons name="arrow-back" size={28} color="#333" />
+            <Ionicons name="arrow-back" size={28} color={colors.text} />
           </TouchableOpacity>
           <Text style={styles.topTitle}>Help & FAQ</Text>
           <View style={{ width: 32 }} /> {/* Spacer */}
@@ -65,9 +66,9 @@ const styles = StyleSheet.create({
     paddingHorizontal: 16,
     paddingTop: 20,
     paddingBottom: 10,
-    backgroundColor: '#ffffff',
+    backgroundColor: colors.surface,
     borderBottomWidth: 1,
-    borderBottomColor: '#dddddd',
+    borderBottomColor: colors.border,
   },
   backButton: {
     width: 32,
@@ -77,18 +78,18 @@ const styles = StyleSheet.create({
     flex: 1,
     fontSize: 20,
     fontWeight: '600',
-    color: '#333333',
+    color: colors.text,
     textAlign: 'center',
   },
   container: {
     padding: 20,
     paddingBottom: 40,
-    backgroundColor: '#f4f6f8',
+    backgroundColor: colors.background,
   },
   heading: {
     fontSize: 22,
     fontWeight: '700',
-    color: '#007AFF',
+    color: colors.primary,
     marginBottom: 20,
   },
   faqItem: {
@@ -97,12 +98,12 @@ const styles = StyleSheet.create({
   question: {
     fontSize: 16,
     fontWeight: '600',
-    color: '#333',
+    color: colors.text,
     marginBottom: 4,
   },
   answer: {
     fontSize: 15,
-    color: '#555',
+    color: colors.textSecondary,
     marginLeft: 8,
     lineHeight: 22,
   },

--- a/MotivezApp/app/menu/map.tsx
+++ b/MotivezApp/app/menu/map.tsx
@@ -3,6 +3,7 @@ import { View, Text, StyleSheet, TouchableOpacity } from 'react-native';
 import { useRouter, Stack } from 'expo-router';
 import { Ionicons } from '@expo/vector-icons';
 import { SafeAreaView } from 'react-native-safe-area-context';
+import { colors } from '../../constants/Colors';
 
 export default function Saved() {
     const router = useRouter();
@@ -10,7 +11,7 @@ export default function Saved() {
   return (
     <>
     <Stack.Screen options={{ headerShown: false }} />
-    <SafeAreaView style={{ flex: 1, backgroundColor: '#efe7ee' }}>
+    <SafeAreaView style={{ flex: 1, backgroundColor: colors.background }}>
     <View style={styles.container}>
         {/* Back button to return to previous screen */}
         <TouchableOpacity onPress={() => router.back()} style={styles.backButton}>
@@ -30,7 +31,7 @@ const styles = StyleSheet.create({
     flex: 1,
     justifyContent: 'center',
     alignItems: 'center',
-    backgroundColor: '#efe7ee',
+    backgroundColor: colors.background,
   },
   text: {
     fontSize: 24,

--- a/MotivezApp/app/menu/memories.tsx
+++ b/MotivezApp/app/menu/memories.tsx
@@ -12,6 +12,7 @@ import {
 import { useRouter, Stack } from 'expo-router';
 import { Ionicons } from '@expo/vector-icons';
 import { SafeAreaView } from 'react-native-safe-area-context';
+import { colors } from '../../constants/Colors';
 
 const SCREEN_WIDTH = Dimensions.get('window').width;
 
@@ -85,7 +86,7 @@ export default function MemoriesScreen() {
         {/* Top Bar */}
         <View style={styles.topBar}>
           <TouchableOpacity onPress={() => router.back()} style={styles.backButton}>
-            <Ionicons name="arrow-back" size={28} color="#333" />
+            <Ionicons name="arrow-back" size={28} color={colors.text} />
           </TouchableOpacity>
           <Text style={styles.topTitle}>Memories</Text>
           <View style={{ width: 32 }} /> {/* Spacer to center title */}
@@ -93,7 +94,7 @@ export default function MemoriesScreen() {
 
         {loading ? (
           <View style={styles.loaderContainer}>
-            <ActivityIndicator size="large" color="#007AFF" />
+            <ActivityIndicator size="large" color={colors.primary} />
             <Text style={styles.loadingText}>Loading Memories...</Text>
           </View>
         ) : (
@@ -121,7 +122,7 @@ export default function MemoriesScreen() {
 const styles = StyleSheet.create({
   safeArea: {
     flex: 1,
-    backgroundColor: '#f4f6f8',
+    backgroundColor: colors.background,
   },
   topBar: {
     flexDirection: 'row',
@@ -129,9 +130,9 @@ const styles = StyleSheet.create({
     paddingHorizontal: 16,
     paddingTop: 20,
     paddingBottom: 10,
-    backgroundColor: '#ffffff',
+    backgroundColor: colors.surface,
     borderBottomWidth: 1,
-    borderBottomColor: '#dddddd',
+    borderBottomColor: colors.border,
   },
   backButton: {
     width: 32,
@@ -141,7 +142,7 @@ const styles = StyleSheet.create({
     flex: 1,
     fontSize: 20,
     fontWeight: '600',
-    color: '#333333',
+    color: colors.text,
     textAlign: 'center',
   },
   loaderContainer: {
@@ -152,7 +153,7 @@ const styles = StyleSheet.create({
   loadingText: {
     marginTop: 12,
     fontSize: 16,
-    color: '#555555',
+    color: colors.textSecondary,
   },
   gridContent: {
     padding: 12,
@@ -182,7 +183,7 @@ const styles = StyleSheet.create({
   memoryTitle: {
     fontSize: 15,
     fontWeight: '600',
-    color: '#333',
+    color: colors.text,
   },
   memoryDate: {
     fontSize: 13,

--- a/MotivezApp/app/menu/messages.tsx
+++ b/MotivezApp/app/menu/messages.tsx
@@ -11,6 +11,7 @@ import {
 import { useRouter, Stack } from 'expo-router';
 import { Ionicons } from '@expo/vector-icons';
 import { SafeAreaView } from 'react-native-safe-area-context';
+import { colors } from '../../constants/Colors';
 
 const dummyChats = [
   {
@@ -102,7 +103,7 @@ export default function MessagesScreen() {
         {/* Top Bar */}
         <View style={styles.topBar}>
           <TouchableOpacity onPress={() => router.back()} style={styles.backButton}>
-            <Ionicons name="arrow-back" size={28} color="#333" />
+            <Ionicons name="arrow-back" size={28} color={colors.text} />
           </TouchableOpacity>
           <Text style={styles.topTitle}>Messages</Text>
           <View style={{ width: 32 }} /> {/* Spacer to center title */}
@@ -110,7 +111,7 @@ export default function MessagesScreen() {
 
         {loading ? (
           <View style={styles.loaderContainer}>
-            <ActivityIndicator size="large" color="#007AFF" />
+            <ActivityIndicator size="large" color={colors.primary} />
             <Text style={styles.loadingText}>Loading Messages...</Text>
           </View>
         ) : chats.length === 0 ? (
@@ -135,7 +136,7 @@ export default function MessagesScreen() {
 const styles = StyleSheet.create({
   safeArea: {
     flex: 1,
-    backgroundColor: '#f4f6f8',
+    backgroundColor: colors.background,
   },
   topBar: {
     flexDirection: 'row',
@@ -143,9 +144,9 @@ const styles = StyleSheet.create({
     paddingHorizontal: 16,
     paddingTop: 20,
     paddingBottom: 10,
-    backgroundColor: '#ffffff',
+    backgroundColor: colors.surface,
     borderBottomWidth: 1,
-    borderBottomColor: '#dddddd',
+    borderBottomColor: colors.border,
   },
   backButton: {
     width: 32,
@@ -155,7 +156,7 @@ const styles = StyleSheet.create({
     flex: 1,
     fontSize: 20,
     fontWeight: '600',
-    color: '#333333',
+    color: colors.text,
     textAlign: 'center',
   },
   loaderContainer: {
@@ -166,7 +167,7 @@ const styles = StyleSheet.create({
   loadingText: {
     marginTop: 12,
     fontSize: 16,
-    color: '#555555',
+    color: colors.textSecondary,
   },
   listContent: {
     paddingTop: 12,
@@ -201,7 +202,7 @@ const styles = StyleSheet.create({
   chatName: {
     fontSize: 16,
     fontWeight: 'bold',
-    color: '#333',
+    color: colors.text,
     flex: 1,
     marginRight: 6,
   },
@@ -211,7 +212,7 @@ const styles = StyleSheet.create({
   },
   lastMessage: {
     fontSize: 15,
-    color: '#666',
+    color: colors.textSecondary,
     maxWidth: '97%',
   },
   unreadBadge: {

--- a/MotivezApp/app/menu/my-motives.tsx
+++ b/MotivezApp/app/menu/my-motives.tsx
@@ -12,6 +12,7 @@ import {
 import { useRouter, Stack } from 'expo-router';
 import { Ionicons } from '@expo/vector-icons';
 import { SafeAreaView } from 'react-native-safe-area-context';
+import { colors } from '../../constants/Colors';
 
 const SCREEN_WIDTH = Dimensions.get('window').width;
 
@@ -92,7 +93,7 @@ export default function MyMotivesScreen() {
         {/* Top Bar */}
         <View style={styles.topBar}>
           <TouchableOpacity onPress={() => router.back()} style={styles.backButton}>
-            <Ionicons name="arrow-back" size={28} color="#333" />
+            <Ionicons name="arrow-back" size={28} color={colors.text} />
           </TouchableOpacity>
           <Text style={styles.topTitle}>My Motivez</Text>
           <View style={{ width: 32 }} /> {/* Spacer to center title */}
@@ -100,7 +101,7 @@ export default function MyMotivesScreen() {
 
         {loading ? (
           <View style={styles.loaderContainer}>
-            <ActivityIndicator size="large" color="#007AFF" />
+            <ActivityIndicator size="large" color={colors.primary} />
             <Text style={styles.loadingText}>Loading your Motivez...</Text>
           </View>
         ) : motives.length === 0 ? (
@@ -125,7 +126,7 @@ export default function MyMotivesScreen() {
 const styles = StyleSheet.create({
   safeArea: {
     flex: 1,
-    backgroundColor: '#f4f6f8',
+    backgroundColor: colors.background,
   },
   topBar: {
     flexDirection: 'row',
@@ -133,9 +134,9 @@ const styles = StyleSheet.create({
     paddingHorizontal: 16,
     paddingTop: 20,
     paddingBottom: 10,
-    backgroundColor: '#ffffff',
+    backgroundColor: colors.surface,
     borderBottomWidth: 1,
-    borderBottomColor: '#dddddd',
+    borderBottomColor: colors.border,
   },
   backButton: {
     width: 32,
@@ -145,7 +146,7 @@ const styles = StyleSheet.create({
     flex: 1,
     fontSize: 20,
     fontWeight: '600',
-    color: '#333333',
+    color: colors.text,
     textAlign: 'center',
   },
   loaderContainer: {
@@ -156,7 +157,7 @@ const styles = StyleSheet.create({
   loadingText: {
     marginTop: 12,
     fontSize: 16,
-    color: '#555555',
+    color: colors.textSecondary,
   },
   listContent: {
     padding: 12,
@@ -188,22 +189,22 @@ const styles = StyleSheet.create({
   motiveTitle: {
     fontSize: 16,
     fontWeight: '700',
-    color: '#333',
+    color: colors.text,
     marginBottom: 4,
   },
   motiveDate: {
     fontSize: 14,
-    color: '#555',
+    color: colors.textSecondary,
   },
   motivePrivacy: {
     fontSize: 13,
     marginTop: 3,
-    color: '#666',
+    color: colors.textSecondary,
   },
   motiveAttendees: {
     fontSize: 13,
     marginTop: 3,
-    color: '#666',
+    color: colors.textSecondary,
   },
   emptyContainer: {
     flex: 1,

--- a/MotivezApp/app/menu/notifications.tsx
+++ b/MotivezApp/app/menu/notifications.tsx
@@ -10,6 +10,7 @@ import {
 import { useRouter, Stack } from 'expo-router';
 import { Ionicons } from '@expo/vector-icons';
 import { SafeAreaView } from 'react-native-safe-area-context';
+import { colors } from '../../constants/Colors';
 
 // Dummy notification data
 const dummyNotifications = [
@@ -86,7 +87,7 @@ export default function NotificationsScreen() {
         {/* Top Bar */}
         <View style={styles.topBar}>
           <TouchableOpacity onPress={() => router.back()} style={styles.backButton}>
-            <Ionicons name="arrow-back" size={28} color="#333" />
+            <Ionicons name="arrow-back" size={28} color={colors.text} />
           </TouchableOpacity>
           <Text style={styles.topTitle}>Notifications</Text>
           <View style={{ width: 32 }} /> {/* Spacer to center title */}
@@ -94,7 +95,7 @@ export default function NotificationsScreen() {
 
         {loading ? (
           <View style={styles.loaderContainer}>
-            <ActivityIndicator size="large" color="#007AFF" />
+            <ActivityIndicator size="large" color={colors.primary} />
             <Text style={styles.loadingText}>Loading notifications...</Text>
           </View>
         ) : notifications.length === 0 ? (
@@ -119,7 +120,7 @@ export default function NotificationsScreen() {
 const styles = StyleSheet.create({
   safeArea: {
     flex: 1,
-    backgroundColor: '#f4f6f8',
+    backgroundColor: colors.background,
   },
   topBar: {
     flexDirection: 'row',
@@ -127,9 +128,9 @@ const styles = StyleSheet.create({
     paddingHorizontal: 16,
     paddingTop: 20,
     paddingBottom: 10,
-    backgroundColor: '#ffffff',
+    backgroundColor: colors.surface,
     borderBottomWidth: 1,
-    borderBottomColor: '#dddddd',
+    borderBottomColor: colors.border,
   },
   backButton: {
     width: 32,
@@ -139,7 +140,7 @@ const styles = StyleSheet.create({
     flex: 1,
     fontSize: 20,
     fontWeight: '600',
-    color: '#333333',
+    color: colors.text,
     textAlign: 'center',
   },
   loaderContainer: {
@@ -150,7 +151,7 @@ const styles = StyleSheet.create({
   loadingText: {
     marginTop: 12,
     fontSize: 16,
-    color: '#555555',
+    color: colors.textSecondary,
   },
   listContent: {
     paddingTop: 12,

--- a/MotivezApp/app/menu/profile.tsx
+++ b/MotivezApp/app/menu/profile.tsx
@@ -54,7 +54,7 @@ export default function Profile() {
       <SafeAreaView style={styles.safeArea}>
         {/* Back Button */}
         <TouchableOpacity onPress={() => router.back()} style={styles.backButton}>
-          <Ionicons name="arrow-back" size={28} color="#333" />
+          <Ionicons name="arrow-back" size={28} color={colors.text} />
         </TouchableOpacity>
 
         {/* Profile Header */}
@@ -138,7 +138,7 @@ export default function Profile() {
 }
 
 const styles = StyleSheet.create({
-  safeArea: { flex: 1, backgroundColor: '#efe7ee' },
+  safeArea: { flex: 1, backgroundColor: colors.background },
   backButton: {
     position: 'absolute',
     top: 50,
@@ -163,11 +163,11 @@ const styles = StyleSheet.create({
   username: {
     fontSize: 22,
     fontWeight: 'bold',
-    color: '#333',
+    color: colors.text,
   },
   bio: {
     fontSize: 14,
-    color: '#555',
+    color: colors.textSecondary,
     marginTop: 4,
   },
   stats: {
@@ -176,7 +176,7 @@ const styles = StyleSheet.create({
     paddingVertical: 12,
     borderTopWidth: 1,
     borderBottomWidth: 1,
-    borderColor: '#ddd',
+    borderColor: colors.border,
     marginHorizontal: 16,
   },
   statBlock: {
@@ -185,11 +185,11 @@ const styles = StyleSheet.create({
   statNumber: {
     fontSize: 18,
     fontWeight: 'bold',
-    color: '#333',
+    color: colors.text,
   },
   statLabel: {
     fontSize: 12,
-    color: '#666',
+    color: colors.textSecondary,
     marginTop: 2,
   },
   tabBar: {
@@ -197,7 +197,7 @@ const styles = StyleSheet.create({
     justifyContent: 'space-around',
     paddingVertical: 12,
     borderBottomWidth: 1,
-    borderColor: '#ddd',
+    borderColor: colors.border,
   },
   grid: {
     padding: gridSpacing,

--- a/MotivezApp/app/menu/saved.tsx
+++ b/MotivezApp/app/menu/saved.tsx
@@ -11,6 +11,7 @@ import {
 import { useRouter, Stack } from 'expo-router';
 import { Ionicons } from '@expo/vector-icons';
 import { SafeAreaView } from 'react-native-safe-area-context';
+import { colors } from '../../constants/Colors';
 
 // Dummy saved motives
 const dummySaved = [
@@ -78,7 +79,7 @@ export default function SavedScreen() {
         {/* Top Bar */}
         <View style={styles.topBar}>
           <TouchableOpacity onPress={() => router.back()} style={styles.backButton}>
-            <Ionicons name="arrow-back" size={28} color="#333" />
+            <Ionicons name="arrow-back" size={28} color={colors.text} />
           </TouchableOpacity>
           <Text style={styles.topTitle}>Saved</Text>
           <View style={{ width: 32 }} /> {/* Spacer to center title */}
@@ -86,7 +87,7 @@ export default function SavedScreen() {
 
         {loading ? (
           <View style={styles.loaderContainer}>
-            <ActivityIndicator size="large" color="#007AFF" />
+            <ActivityIndicator size="large" color={colors.primary} />
             <Text style={styles.loadingText}>Loading saved Motivez...</Text>
           </View>
         ) : saved.length === 0 ? (
@@ -111,7 +112,7 @@ export default function SavedScreen() {
 const styles = StyleSheet.create({
   safeArea: {
     flex: 1,
-    backgroundColor: '#f4f6f8',
+    backgroundColor: colors.background,
   },
   topBar: {
     flexDirection: 'row',
@@ -119,9 +120,9 @@ const styles = StyleSheet.create({
     paddingHorizontal: 16,
     paddingTop: 20,
     paddingBottom: 10,
-    backgroundColor: '#ffffff',
+    backgroundColor: colors.surface,
     borderBottomWidth: 1,
-    borderBottomColor: '#dddddd',
+    borderBottomColor: colors.border,
   },
   backButton: {
     width: 32,
@@ -131,7 +132,7 @@ const styles = StyleSheet.create({
     flex: 1,
     fontSize: 20,
     fontWeight: '600',
-    color: '#333333',
+    color: colors.text,
     textAlign: 'center',
   },
   loaderContainer: {
@@ -142,7 +143,7 @@ const styles = StyleSheet.create({
   loadingText: {
     marginTop: 12,
     fontSize: 16,
-    color: '#555555',
+    color: colors.textSecondary,
   },
   listContent: {
     padding: 12,
@@ -174,12 +175,12 @@ const styles = StyleSheet.create({
   title: {
     fontSize: 16,
     fontWeight: '700',
-    color: '#333',
+    color: colors.text,
     marginBottom: 4,
   },
   meta: {
     fontSize: 13,
-    color: '#555',
+    color: colors.textSecondary,
     marginTop: 2,
   },
   emptyContainer: {

--- a/MotivezApp/app/menu/settings.tsx
+++ b/MotivezApp/app/menu/settings.tsx
@@ -11,6 +11,7 @@ import {
 import { Ionicons } from '@expo/vector-icons';
 import { useRouter, Stack } from 'expo-router';
 import { SafeAreaView } from 'react-native-safe-area-context';
+import { colors } from '../../constants/Colors';
 
 export default function SettingsScreen() {
   const router = useRouter();
@@ -31,7 +32,7 @@ export default function SettingsScreen() {
       <SafeAreaView style={styles.safeArea}>
         <View style={styles.headerRow}>
           <TouchableOpacity onPress={() => router.back()} style={styles.backButton}>
-            <Ionicons name="arrow-back" size={28} color="#333" />
+            <Ionicons name="arrow-back" size={28} color={colors.text} />
           </TouchableOpacity>
           <Text style={styles.title}>Settings</Text>
         </View>
@@ -136,18 +137,18 @@ export default function SettingsScreen() {
 }
 
 const styles = StyleSheet.create({
-  safeArea: { flex: 1, backgroundColor: '#efe7ee' },
+  safeArea: { flex: 1, backgroundColor: colors.background },
   headerRow: {
     flexDirection: 'row',
     alignItems: 'center',
     paddingVertical: 12,
     paddingHorizontal: 16,
     borderBottomWidth: 1,
-    borderColor: '#ddd',
+    borderColor: colors.border,
     backgroundColor: '#fff',
   },
   backButton: { marginRight: 12 },
-  title: { fontSize: 20, fontWeight: 'bold', color: '#333' },
+  title: { fontSize: 20, fontWeight: 'bold', color: colors.text },
 
   container: {
     paddingVertical: 16,
@@ -168,15 +169,15 @@ const styles = StyleSheet.create({
     paddingHorizontal: 16,
     backgroundColor: '#fff',
     borderBottomWidth: 1,
-    borderColor: '#ececec',
+    borderColor: colors.border,
   },
   rowLeft: { flexDirection: 'row', alignItems: 'center' },
-  rowLabel: { marginLeft: 12, fontSize: 16, color: '#333' },
-  rowValue: { color: '#666', fontSize: 14 },
+  rowLabel: { marginLeft: 12, fontSize: 16, color: colors.text },
+  rowValue: { color: colors.textSecondary, fontSize: 14 },
 
   logoutRow: {
     marginTop: 32,
     borderTopWidth: 1,
-    borderColor: '#ececec',
+    borderColor: colors.border,
   },
 });

--- a/MotivezApp/constants/Colors.ts
+++ b/MotivezApp/constants/Colors.ts
@@ -1,0 +1,9 @@
+export const colors = {
+  background: '#f4f6f8',
+  surface: '#ffffff',
+  primary: '#007AFF',
+  danger: '#e53935',
+  text: '#333333',
+  textSecondary: '#555555',
+  border: '#dddddd',
+};


### PR DESCRIPTION
## Summary
- add a shared color palette in `constants/Colors.ts`
- update all menu screens to import the palette
- apply themed colors for backgrounds, text and borders

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d4a61cc0083328bc804aaf091f154