### PR TITLE
Add theme context with dark mode

### DIFF
--- a/MotivezApp/app/_layout.tsx
+++ b/MotivezApp/app/_layout.tsx
@@ -4,10 +4,12 @@ import { LogBox, StatusBar } from "react-native";
 import { SafeAreaProvider } from 'react-native-safe-area-context';
 import { ScrollProvider } from "./context/ScrollContext";
 import { supabase } from '../lib/supabaseClient';
+import { ThemeProvider, useTheme } from '../theme/ThemeContext';
 
 LogBox.ignoreAllLogs(true);
 
-export default function RootLayout() {
+function InnerLayout() {
+  const { theme } = useTheme();
 
   useEffect(() => {
     const login = async () => {
@@ -24,7 +26,7 @@ export default function RootLayout() {
 
   return (
     <SafeAreaProvider>
-      <StatusBar barStyle="dark-content" />
+      <StatusBar barStyle={theme === 'dark' ? 'light-content' : 'dark-content'} />
       <ScrollProvider>
         <Stack
           screenOptions={{
@@ -59,5 +61,13 @@ export default function RootLayout() {
         </Stack>
       </ScrollProvider>
     </SafeAreaProvider>
+  );
+}
+
+export default function RootLayout() {
+  return (
+    <ThemeProvider>
+      <InnerLayout />
+    </ThemeProvider>
   );
 }

--- a/MotivezApp/components/BottomAccountDrawer.tsx
+++ b/MotivezApp/components/BottomAccountDrawer.tsx
@@ -26,6 +26,7 @@ export default function BottomAccountDrawer({
 }: BottomAccountDrawerProps) {
   const [mounted, setMounted] = useState(isVisible);
   const translateY = useRef(new Animated.Value(SCREEN_HEIGHT)).current;
+  const { colors } = useTheme();
 
   useEffect(() => {
     if (isVisible) {
@@ -52,15 +53,15 @@ export default function BottomAccountDrawer({
     <View style={styles.wrapper}>
       {/* Backdrop */}
       <TouchableWithoutFeedback onPress={onClose}>
-        <View style={styles.backdrop} />
+        <View style={[styles.backdrop, { backgroundColor: colors.backdrop }]} />
       </TouchableWithoutFeedback>
 
       {/* Bottom Drawer */}
-      <Animated.View style={[styles.drawer, { transform: [{ translateY }] }]}>
+      <Animated.View style={[styles.drawer, { transform: [{ translateY }], backgroundColor: colors.card }]}>
         <View style={styles.handle} />
 
         {/* Title */}
-        <Text style={styles.title}>Switch Profile</Text>
+        <Text style={[styles.title, { color: colors.text }]}>Switch Profile</Text>
 
         {/* Account List */}
         {accounts.map((acct) => (
@@ -74,12 +75,12 @@ export default function BottomAccountDrawer({
             }}
           >
             <Image source={{ uri: acct.avatarUri }} style={styles.avatar} />
-            <Text style={styles.accountName}>{acct.name}</Text>
+            <Text style={[styles.accountName, { color: colors.text }]}>{acct.name}</Text>
           </TouchableOpacity>
         ))}
 
         {/* Divider */}
-        <View style={styles.divider} />
+        <View style={[styles.divider, { backgroundColor: colors.border }]} />
 
         {/* Sign in with new account */}
         <TouchableOpacity
@@ -89,8 +90,8 @@ export default function BottomAccountDrawer({
             onClose();
           }}
         >
-          <Ionicons name="add-circle-outline" size={24} color="#333" />
-          <Text style={styles.newAccountText}>Sign in with another account</Text>
+          <Ionicons name="add-circle-outline" size={24} color={colors.text} />
+          <Text style={[styles.newAccountText, { color: colors.text }]}>Sign in with another account</Text>
         </TouchableOpacity>
       </Animated.View>
     </View>
@@ -98,6 +99,7 @@ export default function BottomAccountDrawer({
 }
 
 import { Ionicons } from "@expo/vector-icons";
+import { useTheme } from "../theme/ThemeContext";
 
 const styles = StyleSheet.create({
   wrapper: {

--- a/MotivezApp/components/MenuDrawer.tsx
+++ b/MotivezApp/components/MenuDrawer.tsx
@@ -15,6 +15,7 @@ import {
 import { Ionicons } from "@expo/vector-icons";
 import { useRouter } from "expo-router";
 import BottomAccountDrawer from "./BottomAccountDrawer";
+import { useTheme } from "../theme/ThemeContext";
 
 const SCREEN_WIDTH = Dimensions.get("window").width;
 
@@ -36,6 +37,7 @@ export default function MenuDrawer({ isVisible, onClose }: MenuDrawerProps) {
   const [bottomVisible, setBottomVisible] = useState(false);
   const slideAnim = useRef(new Animated.Value(-SCREEN_WIDTH)).current;
   const router = useRouter();
+  const { colors } = useTheme();
 
   useLayoutEffect(() => {
     if (isVisible) {
@@ -67,19 +69,19 @@ export default function MenuDrawer({ isVisible, onClose }: MenuDrawerProps) {
       <View style={styles.drawerWrapper}>
         {/* Backdrop: clicking it closes the drawer */}
         <TouchableWithoutFeedback onPress={onClose}>
-          <View style={styles.backdrop} />
+          <View style={[styles.backdrop, { backgroundColor: colors.backdrop }]} />
         </TouchableWithoutFeedback>
 
         {/* Animated drawer sliding in/out from left */}
         <Animated.View
           style={[
             styles.drawer,
-            { transform: [{ translateX: slideAnim }] },
+            { transform: [{ translateX: slideAnim }], backgroundColor: colors.card },
           ]}
         >
           {/* Close “X” button */}
           <TouchableOpacity onPress={onClose} style={styles.closeButton}>
-            <Ionicons name="close" size={33} color="#333" />
+            <Ionicons name="close" size={33} color={colors.text} />
           </TouchableOpacity>
 
           {/* Wrap all menu items in a ScrollView */}
@@ -106,8 +108,8 @@ export default function MenuDrawer({ isVisible, onClose }: MenuDrawerProps) {
                 onClose();
               }}
             >
-              <Ionicons name="person-outline" size={22} color="#333" />
-              <Text style={styles.drawerItemText}>Profile</Text>
+              <Ionicons name="person-outline" size={22} color={colors.text} />
+              <Text style={[styles.drawerItemText, { color: colors.text }]}>Profile</Text>
             </TouchableOpacity>
 
             {/* “My Motives” */}
@@ -118,8 +120,8 @@ export default function MenuDrawer({ isVisible, onClose }: MenuDrawerProps) {
                 onClose();
               }}
             >
-              <Ionicons name="list-outline" size={22} color="#333" />
-              <Text style={styles.drawerItemText}>My Motives</Text>
+              <Ionicons name="list-outline" size={22} color={colors.text} />
+              <Text style={[styles.drawerItemText, { color: colors.text }]}>My Motives</Text>
             </TouchableOpacity>
 
             {/* “Add / Invite Friends” */}
@@ -130,8 +132,8 @@ export default function MenuDrawer({ isVisible, onClose }: MenuDrawerProps) {
                 onClose();
               }}
             >
-              <Ionicons name="person-add-outline" size={22} color="#333" />
-              <Text style={styles.drawerItemText}>Add / Invite Friends</Text>
+              <Ionicons name="person-add-outline" size={22} color={colors.text} />
+              <Text style={[styles.drawerItemText, { color: colors.text }]}>Add / Invite Friends</Text>
             </TouchableOpacity>
 
             <View style={styles.sectionDivider} />
@@ -144,8 +146,8 @@ export default function MenuDrawer({ isVisible, onClose }: MenuDrawerProps) {
                 onClose();
               }}
             >
-              <Ionicons name="people-outline" size={22} color="#333" />
-              <Text style={styles.drawerItemText}>Friends</Text>
+              <Ionicons name="people-outline" size={22} color={colors.text} />
+              <Text style={[styles.drawerItemText, { color: colors.text }]}>Friends</Text>
             </TouchableOpacity>
 
             <TouchableOpacity
@@ -155,8 +157,8 @@ export default function MenuDrawer({ isVisible, onClose }: MenuDrawerProps) {
                 onClose();
               }}
             >
-              <Ionicons name="chatbubble-ellipses-outline" size={22} color="#333" />
-              <Text style={styles.drawerItemText}>Messages</Text>
+              <Ionicons name="chatbubble-ellipses-outline" size={22} color={colors.text} />
+              <Text style={[styles.drawerItemText, { color: colors.text }]}>Messages</Text>
             </TouchableOpacity>
 
             <TouchableOpacity
@@ -166,8 +168,8 @@ export default function MenuDrawer({ isVisible, onClose }: MenuDrawerProps) {
                 onClose();
               }}
             >
-              <Ionicons name="bookmark-outline" size={22} color="#333" />
-              <Text style={styles.drawerItemText}>Saved Motives</Text>
+              <Ionicons name="bookmark-outline" size={22} color={colors.text} />
+              <Text style={[styles.drawerItemText, { color: colors.text }]}>Saved Motives</Text>
             </TouchableOpacity>
 
             <View style={styles.sectionDivider} />
@@ -180,8 +182,8 @@ export default function MenuDrawer({ isVisible, onClose }: MenuDrawerProps) {
                 onClose();
               }}
             >
-              <Ionicons name="compass-outline" size={22} color="#333" />
-              <Text style={styles.drawerItemText}>Explore / Trending</Text>
+              <Ionicons name="compass-outline" size={22} color={colors.text} />
+              <Text style={[styles.drawerItemText, { color: colors.text }]}>Explore / Trending</Text>
             </TouchableOpacity>
 
             <TouchableOpacity
@@ -191,8 +193,8 @@ export default function MenuDrawer({ isVisible, onClose }: MenuDrawerProps) {
                 onClose();
               }}
             >
-              <Ionicons name="map-outline" size={22} color="#333" />
-              <Text style={styles.drawerItemText}>Nearby Map</Text>
+              <Ionicons name="map-outline" size={22} color={colors.text} />
+              <Text style={[styles.drawerItemText, { color: colors.text }]}>Nearby Map</Text>
             </TouchableOpacity>
 
             <TouchableOpacity
@@ -202,8 +204,8 @@ export default function MenuDrawer({ isVisible, onClose }: MenuDrawerProps) {
                 onClose();
               }}
             >
-              <Ionicons name="pricetags-outline" size={22} color="#333" />
-              <Text style={styles.drawerItemText}>Categories</Text>
+              <Ionicons name="pricetags-outline" size={22} color={colors.text} />
+              <Text style={[styles.drawerItemText, { color: colors.text }]}>Categories</Text>
             </TouchableOpacity>
 
             <View style={styles.sectionDivider} />
@@ -216,8 +218,8 @@ export default function MenuDrawer({ isVisible, onClose }: MenuDrawerProps) {
                 onClose();
               }}
             >
-              <Ionicons name="calendar-outline" size={22} color="#333" />
-              <Text style={styles.drawerItemText}>Upcoming Events</Text>
+              <Ionicons name="calendar-outline" size={22} color={colors.text} />
+              <Text style={[styles.drawerItemText, { color: colors.text }]}>Upcoming Events</Text>
             </TouchableOpacity>
 
             <TouchableOpacity
@@ -227,8 +229,8 @@ export default function MenuDrawer({ isVisible, onClose }: MenuDrawerProps) {
                 onClose();
               }}
             >
-              <Ionicons name="time-outline" size={22} color="#333" />
-              <Text style={styles.drawerItemText}>Past Memories</Text>
+              <Ionicons name="time-outline" size={22} color={colors.text} />
+              <Text style={[styles.drawerItemText, { color: colors.text }]}>Past Memories</Text>
             </TouchableOpacity>
 
             <View style={styles.sectionDivider} />
@@ -241,8 +243,8 @@ export default function MenuDrawer({ isVisible, onClose }: MenuDrawerProps) {
                 onClose();
               }}
             >
-              <Ionicons name="settings-outline" size={22} color="#333" />
-              <Text style={styles.drawerItemText}>Settings</Text>
+              <Ionicons name="settings-outline" size={22} color={colors.text} />
+              <Text style={[styles.drawerItemText, { color: colors.text }]}>Settings</Text>
             </TouchableOpacity>
 
             <TouchableOpacity
@@ -252,8 +254,8 @@ export default function MenuDrawer({ isVisible, onClose }: MenuDrawerProps) {
                 onClose();
               }}
             >
-              <Ionicons name="notifications-outline" size={22} color="#333" />
-              <Text style={styles.drawerItemText}>Notifications</Text>
+              <Ionicons name="notifications-outline" size={22} color={colors.text} />
+              <Text style={[styles.drawerItemText, { color: colors.text }]}>Notifications</Text>
             </TouchableOpacity>
 
             <TouchableOpacity
@@ -263,8 +265,8 @@ export default function MenuDrawer({ isVisible, onClose }: MenuDrawerProps) {
                 onClose();
               }}
             >
-              <Ionicons name="help-circle-outline" size={22} color="#333" />
-              <Text style={styles.drawerItemText}>Help & Feedback</Text>
+              <Ionicons name="help-circle-outline" size={22} color={colors.text} />
+              <Text style={[styles.drawerItemText, { color: colors.text }]}>Help & Feedback</Text>
             </TouchableOpacity>
 
             <TouchableOpacity
@@ -274,8 +276,8 @@ export default function MenuDrawer({ isVisible, onClose }: MenuDrawerProps) {
                 onClose();
               }}
             >
-              <Ionicons name="information-circle-outline" size={22} color="#333" />
-              <Text style={styles.drawerItemText}>About Motivez</Text>
+              <Ionicons name="information-circle-outline" size={22} color={colors.text} />
+              <Text style={[styles.drawerItemText, { color: colors.text }]}>About Motivez</Text>
             </TouchableOpacity>
 
             <View style={styles.sectionDivider} />
@@ -288,8 +290,8 @@ export default function MenuDrawer({ isVisible, onClose }: MenuDrawerProps) {
                 console.log("Logging out...");
               }}
             >
-              <Ionicons name="log-out-outline" size={22} color="#e53935" />
-              <Text style={[styles.drawerItemText, { color: "#e53935" }]}>Log Out</Text>
+              <Ionicons name="log-out-outline" size={22} color={colors.primary} />
+              <Text style={[styles.drawerItemText, { color: colors.primary }]}>Log Out</Text>
             </TouchableOpacity>
           </ScrollView>
         </Animated.View>

--- a/MotivezApp/theme/ThemeContext.tsx
+++ b/MotivezApp/theme/ThemeContext.tsx
@@ -1,0 +1,33 @@
+import React, { createContext, useState, useContext, ReactNode } from 'react';
+import { Appearance } from 'react-native';
+import { lightColors, darkColors, Colors } from './colors';
+
+type Theme = 'light' | 'dark';
+
+interface ThemeContextValue {
+  theme: Theme;
+  colors: Colors;
+  toggleTheme: () => void;
+}
+
+const ThemeContext = createContext<ThemeContextValue>({
+  theme: 'light',
+  colors: lightColors,
+  toggleTheme: () => {},
+});
+
+export const ThemeProvider = ({ children }: { children: ReactNode }) => {
+  const scheme = Appearance.getColorScheme();
+  const [theme, setTheme] = useState<Theme>(scheme === 'dark' ? 'dark' : 'light');
+
+  const toggleTheme = () => setTheme(t => (t === 'light' ? 'dark' : 'light'));
+  const colors = theme === 'dark' ? darkColors : lightColors;
+
+  return (
+    <ThemeContext.Provider value={{ theme, colors, toggleTheme }}>
+      {children}
+    </ThemeContext.Provider>
+  );
+};
+
+export const useTheme = () => useContext(ThemeContext);

--- a/MotivezApp/theme/colors.ts
+++ b/MotivezApp/theme/colors.ts
@@ -1,0 +1,19 @@
+export const lightColors = {
+  background: '#ffffff',
+  card: '#ffffff',
+  text: '#333333',
+  primary: '#FF4D6D',
+  border: '#ececec',
+  backdrop: 'rgba(0,0,0,0.2)',
+};
+
+export const darkColors = {
+  background: '#000000',
+  card: '#1a1a1a',
+  text: '#ffffff',
+  primary: '#FF4D6D',
+  border: '#333333',
+  backdrop: 'rgba(255,255,255,0.2)',
+};
+
+export type Colors = typeof lightColors;


### PR DESCRIPTION
## Summary
- add color constants for light and dark modes
- create ThemeProvider and hook
- wrap application in ThemeProvider and set StatusBar style
- apply theme colors to drawer components

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859438a09808332bca27f7cd893adc0